### PR TITLE
Fix id typo

### DIFF
--- a/client/views/home/_editSprintTitle.html
+++ b/client/views/home/_editSprintTitle.html
@@ -2,7 +2,7 @@
   <form role="form" id="editSprintTitleForm">
     <div class="form-group">
       <div class="input-group col-xs-5">
-        <input id="editSptintTitleInput" class="form-control" value="{{title}}" type="text" autofocus/>
+        <input id="editSprintTitleInput" class="form-control" value="{{title}}" type="text" autofocus/>
       </div>
     </div>
   </form>

--- a/client/views/home/_editSprintTitle.js
+++ b/client/views/home/_editSprintTitle.js
@@ -2,7 +2,7 @@ Template.editSprintTitle.events({
   'submit #editSprintTitleForm': function(e) {
     e.preventDefault();
     var sprintId = Session.get('editingSprintTitleId');
-    var newTitle = $('#editSptintTitleInput').val();
+    var newTitle = $('#editSprintTitleInput').val();
     Sprints.update({_id: sprintId}, {$set: {title: newTitle}});
     Session.set('editingSprintTitleId', false);
   },


### PR DESCRIPTION
The id of the edit Sprint title field had a typo.
