### PR TITLE
Keep Sprint titles from being empty

### DIFF
--- a/client/views/home/_editSprintTitle.js
+++ b/client/views/home/_editSprintTitle.js
@@ -14,7 +14,9 @@ Template.editSprintTitle.rendered = function() {
   $('#' + editingTitle).editable({
     mode: 'inline',
     success: function(response, newValue) {
-      Sprints.update({_id: editingTitle}, {$set: {title: newValue}});
+      if (newValue !== '') {
+        Sprints.update({_id: editingTitle}, {$set: {title: newValue}});
+      }
       Session.set('editingSprintTitleId', false);
     }
   });


### PR DESCRIPTION
Now, you can't update a title to an empty string.
