### PR TITLE
Fix sprint title edit field

### DIFF
--- a/client/views/home/_editSprintTitle.js
+++ b/client/views/home/_editSprintTitle.js
@@ -17,5 +17,5 @@ Template.editSprintTitle.events({
 });
 
 Template.editSprintTitle.rendered = function() {
-  $('#' + Session.get('editingSprintTitleId')).click();
+  $('#' + Session.get('editingSprintTitleId')).focus();
 }


### PR DESCRIPTION
I specifically fixed the problem with the focus not being on the input
field when you hit the edit button.
