### PR TITLE
Fix the RegisterHelpers after the update to 1.0

### DIFF
--- a/client/helpers/routes.js
+++ b/client/helpers/routes.js
@@ -1,9 +1,9 @@
 // Helper for current route name.
 UI.registerHelper('currentRouteName',function(){
-  return Router.current() ? Router.current().route.name : '';
+  return Router.current() ? Router.current().route.getName() : '';
 });
 
 // Helper to help check the current route.
 UI.registerHelper('RouteIs', function (routeName) {
-  return Router.current().route.name === routeName;
+  return Router.current().route.getName() === routeName;
 });


### PR DESCRIPTION
the 2 header Links SPRINTS and ARCHIVED SPRINTS were not showing up on the home page anymore. 

Iron:router had been upgraded and this broke the RegisterHelpers.
